### PR TITLE
Adjustable Horizontal Overscan.

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -631,7 +631,7 @@ static MDFNSetting PCESettings[] =
   { "pce_fast.ocmultiplier", MDFNSF_EMU_STATE | MDFNSF_UNTRUSTED_SAFE, "CPU overclock multiplier.", NULL, MDFNST_UINT, "1", "1", "100"},
   { "pce_fast.cdspeed", MDFNSF_EMU_STATE | MDFNSF_UNTRUSTED_SAFE, "CD-ROM data transfer speed multiplier", NULL, MDFNST_UINT, "1", "1", "100" },
   { "pce_fast.nospritelimit", MDFNSF_NOFLAGS, "Remove 16-sprites-per-scanline hardware limit.", NULL, MDFNST_BOOL, "0" },
-  { "pce_fast.hoverscan", MDFNSF_NOFLAGS, "Display 352 pixels width instead of 341.", NULL, MDFNST_BOOL, "0" },
+  { "pce_fast.hoverscan", MDFNSF_NOFLAGS, "Reduce 352 pixels width overscan.", NULL, MDFNST_BOOL, "0" },
 
   { "pce_fast.cdbios", MDFNSF_EMU_STATE, "Path to the CD BIOS", NULL, MDFNST_STRING, "syscard3.pce" },
 

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -631,7 +631,7 @@ static MDFNSetting PCESettings[] =
   { "pce_fast.ocmultiplier", MDFNSF_EMU_STATE | MDFNSF_UNTRUSTED_SAFE, "CPU overclock multiplier.", NULL, MDFNST_UINT, "1", "1", "100"},
   { "pce_fast.cdspeed", MDFNSF_EMU_STATE | MDFNSF_UNTRUSTED_SAFE, "CD-ROM data transfer speed multiplier", NULL, MDFNST_UINT, "1", "1", "100" },
   { "pce_fast.nospritelimit", MDFNSF_NOFLAGS, "Remove 16-sprites-per-scanline hardware limit.", NULL, MDFNST_BOOL, "0" },
-  { "pce_fast.hoverscan", MDFNSF_NOFLAGS, "Reduce 352 pixels width overscan.", NULL, MDFNST_BOOL, "0" },
+  { "pce_fast.hoverscan", MDFNSF_NOFLAGS, "Reduce 352 pixels width overscan.", NULL, MDFNST_UINT, "300", "300", "352" },
 
   { "pce_fast.cdbios", MDFNSF_EMU_STATE, "Path to the CD BIOS", NULL, MDFNST_STRING, "syscard3.pce" },
 
@@ -1421,11 +1421,7 @@ static void check_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (strcmp(var.value, "disabled") == 0)
-         setting_pce_hoverscan = 0;
-      else if (strcmp(var.value, "enabled") == 0)
-         setting_pce_hoverscan = 1;
-	 MDFNI_SetSettingB("pce_fast.hoverscan", setting_pce_hoverscan);
+      setting_pce_hoverscan = atoi(var.value);
    }
 	
    var.key = "pce_initial_scanline";
@@ -1793,7 +1789,7 @@ void retro_set_environment(retro_environment_t cb)
       { "pce_fast_cdimagecache", "CD Image Cache (Restart); disabled|enabled" },
       { "pce_nospritelimit", "No Sprite Limit (Restart); disabled|enabled" },
       { "pce_ocmultiplier", "CPU Overclock Multiplier (Restart); 1|2|3|4|5|6|7|8|9|10|20|30|40|50" },
-      { "pce_hoverscan", "Horizontal Overscan; disabled|enabled" },
+      { "pce_hoverscan", "Horizontal Overscan (352 Width Mode Only); 352|300|302|304|306|308|310|312|314|316|318|320|322|324|326|328|330|332|334|336|338|340|342|344|346|348|350" },
       { "pce_initial_scanline", "Initial scanline; 3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|0|1|2" },
       { "pce_last_scanline", "Last scanline; 242|208|209|210|211|212|213|214|215|216|217|218|219|220|221|222|223|224|225|226|227|228|229|230|231|232|233|234|235|236|237|238|239|240|241" },
       { "pce_cddavolume", "(CD) CDDA Volume %; 100|110|120|130|140|150|160|170|180|190|200|0|10|20|30|40|50|60|70|80|90" },

--- a/mednafen/pce_fast/vdc.cpp
+++ b/mednafen/pce_fast/vdc.cpp
@@ -37,7 +37,6 @@ static uint32 userle; // User layer enable.
 static uint32 disabled_layer_color;
 
 static bool unlimited_sprites;
-static bool hoverscan;
 
 #define ULE_BG0		1
 #define ULE_SPR0	2
@@ -46,7 +45,7 @@ static bool hoverscan;
 
 static const uint8 bat_width_shift_tab[4] = { 5, 6, 7, 7 };
 static const uint8 bat_height_mask_tab[2] = { 32 - 1, 64 - 1 };
-static const int defined_width[3] = { 256, 341, 512};
+static int defined_width[3] = { 256, 352, 512};
 
 static unsigned int VDS;
 static unsigned int VSW;
@@ -882,8 +881,9 @@ void VDC_RunFrame(EmulateSpecStruct *espec, bool IsHES)
   DisplayRect->h = MDFN_GetSettingUI("pce_fast.slend") - DisplayRect->y + 1;
  }
 	
- if (hoverscan != MDFN_GetSettingB("pce_fast.hoverscan"))
-  hoverscan = MDFN_GetSettingB("pce_fast.hoverscan");
+ //Change 352 mode width without restart
+ if (defined_width[1] != MDFN_GetSettingUI("pce_fast.hoverscan"))
+  defined_width[1] = MDFN_GetSettingUI("pce_fast.hoverscan");
 	
  do
  {
@@ -958,12 +958,7 @@ void VDC_RunFrame(EmulateSpecStruct *espec, bool IsHES)
   {
 	  
    DisplayRect->x = 0;
-   
-   if(hoverscan == 1 && vce.dot_clock == 1){
-			   DisplayRect->w = 352;
-		   }else{
-			   DisplayRect->w = defined_width[vce.dot_clock];
-   }
+   DisplayRect->w = defined_width[vce.dot_clock];
   }
 
   for(int chip = 0; chip < VDC_TotalChips; chip++)
@@ -1076,16 +1071,12 @@ void VDC_RunFrame(EmulateSpecStruct *espec, bool IsHES)
 	  
 	  //Centre any picture thinner than its display mode width
 	  if(width > 0 && width < defined_width[vce.dot_clock]){
-		  if(vce.dot_clock ==1 && hoverscan ==1){
-			target_offset = (352 - width)/2;
-		  }else{
-			target_offset = (defined_width[vce.dot_clock] - width)/2;
-		  }
+		  target_offset = (defined_width[vce.dot_clock] - width)/2;
 	  }
 	  
-	  //Centre cropping of overscan OFF
-	  if(vce.dot_clock ==1 && hoverscan ==0 && width > 341){
-		  target_offset = (341 - width)/2;
+	  //Centre overscan cropping
+	  if(vce.dot_clock == 1 && defined_width[1] < width){
+		  target_offset += (defined_width[1] - width) / 2;
 	  }
 	  
 	 // Align TV Sport Basketball
@@ -1095,12 +1086,12 @@ void VDC_RunFrame(EmulateSpecStruct *espec, bool IsHES)
 	 
 	 // Semi-hack for Asuka 120%
 	 if(vce.dot_clock == 1 && M_vdc_HDS == 5 && M_vdc_HDE == 6 && M_vdc_HDW == 43 && M_vdc_HSW == 2)
-	  target_offset = 0;
+	  target_offset += 8;
 	 else if(vce.dot_clock == 0 && M_vdc_HDS == 2 && M_vdc_HDE == 3 && M_vdc_HDW == 33 && M_vdc_HSW == 2)
 	  target_offset = 0;
 	 // and for Addams Family
 	 else if(vce.dot_clock == 1 && M_vdc_HDS == 4 && M_vdc_HDE == 4 && M_vdc_HDW == 43 && M_vdc_HSW == 9)
-	  target_offset = 0;
+	  target_offset += 4;
 
       if(target_offset < 0)
       {
@@ -1229,11 +1220,7 @@ void VDC_RunFrame(EmulateSpecStruct *espec, bool IsHES)
   //printf("%d\n", vce.lc263);
  } while(frame_counter != VBlankFL); // big frame loop!
 
-  if(vce.dot_clock ==1 && hoverscan ==1){
-	DisplayRect->w = 352;
-  }else{
-	DisplayRect->w = defined_width[vce.dot_clock];
-  }
+  DisplayRect->w = defined_width[vce.dot_clock];
 }
 
 void VDC_Reset(void)
@@ -1262,7 +1249,7 @@ void VDC_Power(void)
 void VDC_Init(int sgx)
 {
  unlimited_sprites = MDFN_GetSettingB("pce_fast.nospritelimit");
- hoverscan = MDFN_GetSettingB("pce_fast.hoverscan");
+ defined_width[1] = MDFN_GetSettingUI("pce_fast.hoverscan");
  userle = ~0;
 
  VDC_TotalChips = sgx ? 2 : 1;

--- a/mednafen/settings.cpp
+++ b/mednafen/settings.cpp
@@ -23,7 +23,7 @@
 
 int setting_initial_scanline = 0;
 int setting_last_scanline = 242;
-int setting_pce_hoverscan = 0;
+int setting_pce_hoverscan = 352;
 int setting_pce_fast_nospritelimit = 0;
 int setting_pce_overclocked = 1;
 int setting_pce_fast_cddavolume = 100;
@@ -92,8 +92,6 @@ bool MDFN_GetSettingB(const char *name)
       return 0;
    if (!strcmp("pce_fast.adpcmlp", name))
       return 0;
-   if (!strcmp("pce_fast.hoverscan", name))
-      return setting_pce_hoverscan;
    /* CDROM */
    if (!strcmp("cdrom.lec_eval", name))
       return 1;


### PR DESCRIPTION
Horizontal Overscan can be changed from 300 to 352 pixels wide.
One step is 2 pixels.

Odd numbers (like 341 old default) were causing issues with AMD and Intel cards, so that should fix that.

Adjusted hacks values for Asuka 120% (ideal overscan is 336) and Addams Family (ideal overscan is 344).