### PR TITLE
Fix CRC lookup table for EDC poly

### DIFF
--- a/mednafen/cdrom/lec.c
+++ b/mednafen/cdrom/lec.c
@@ -151,9 +151,13 @@ static void crc_table_init(void)
 
       for (j = 0; j < 8; j++)
       {
-         r <<= 1;
          if ((r & 0x80000000) != 0)
+         {
+            r <<= 1;
             r ^= EDC_POLY;
+         }
+         else
+            r <<= 1;
       }
 
       r = mirror_bits(r, 32);


### PR DESCRIPTION
This fixes loading Mode1/2048 cdimages( .cue with wav files and CHD created from mode1/2048 images). This is caused by incorrectly generated crc lookup table for EDC Poly.

Related issues:
https://github.com/libretro/beetle-supergrafx-libretro/issues/21
https://github.com/libretro/beetle-supergrafx-libretro/issues/18
https://github.com/libretro/beetle-supergrafx-libretro/issues/13