### PR TITLE
Runframe cleanup

### DIFF
--- a/mednafen/pce_fast/vdc.cpp
+++ b/mednafen/pce_fast/vdc.cpp
@@ -813,7 +813,7 @@ void DrawOverscan(const vdc_t *vdc, uint16_t *target, const MDFN_Rect *lw, const
 {
  uint32 os_color;
 
- // SuperGrafx needs MAKECOLOR_PCE() so it wont have much wierd overscan colors 
+ // SuperGrafx needs MAKECOLOR_PCE() so it wont have much wierd overscan colors
  // when running in non-sgx mode
  if (VDC_TotalChips == 2)
   os_color = MAKECOLOR_PCE(vce.color_table_cache[0x100]);
@@ -828,7 +828,7 @@ void DrawOverscan(const vdc_t *vdc, uint16_t *target, const MDFN_Rect *lw, const
   for(; x < vpl; x++)
    target[x] = os_color;
 
-   x = vpr;
+  x = vpr;
  }
 
  for(; x < lw->x + lw->w; x++)

--- a/mednafen/pce_fast/vdc.cpp
+++ b/mednafen/pce_fast/vdc.cpp
@@ -821,22 +821,18 @@ void DrawOverscan(const vdc_t *vdc, uint16_t *target, const MDFN_Rect *lw, const
   os_color = vce.color_table_cache[0x100];
 
  //printf("%d %d\n", lw->x, lw->w);
- if(full)
+ int x = lw->x;
+
+ if(!full)
  {
-  // Fill in entire viewport(horizontally!) with overscan color
-  for(int x = lw->x; x < lw->x + lw->w; x++)
-   target[x] = os_color;
- }
- else
- {
-  // Fill in viewport to the left of HDW with overscan color.
-  for(int x = lw->x; x < vpl; x++)
+  for(; x < vpl; x++)
    target[x] = os_color;
 
-  // Fill in viewport to the right of HDW with overscan color.
-  for(int x = vpr; x < lw->x + lw->w; x++)
-   target[x] = os_color;
+   x = vpr;
  }
+
+ for(; x < lw->x + lw->w; x++)
+  target[x] = os_color;
 }
 
 void VDC_RunFrame(EmulateSpecStruct *espec, bool IsHES)

--- a/mednafen/pce_fast/vpc_mix_inner.inc
+++ b/mednafen/pce_fast/vpc_mix_inner.inc
@@ -33,7 +33,7 @@
 	 }
 
     if (vdc1_pixel & ALPHA_MASK)
-    target[x] = MAKECOLOR_PCE(vdc2_pixel);
+     target[x] = MAKECOLOR_PCE(vdc2_pixel);
     else
-    target[x] = MAKECOLOR_PCE(vdc1_pixel);
+     target[x] = MAKECOLOR_PCE(vdc1_pixel);
 

--- a/mednafen/settings.cpp
+++ b/mednafen/settings.cpp
@@ -55,9 +55,9 @@ uint64 MDFN_GetSettingUI(const char *name)
    if (!strcmp("pce_fast.slstart", name))
       return setting_initial_scanline;
    if (!strcmp("pce_fast.slend", name))
-      return setting_last_scanline; 
+      return setting_last_scanline;
    if (!strcmp("pce_fast.hoverscan", name))
-      return setting_pce_hoverscan; 
+      return setting_pce_hoverscan;
 
    fprintf(stderr, "unhandled setting UI: %s\n", name);
    return 0;
@@ -71,6 +71,8 @@ int64 MDFN_GetSettingI(const char *name)
 
 double MDFN_GetSettingF(const char *name)
 {
+   if (!strcmp("pce_fast.mouse_sensitivity", name))
+      return 1.25;
    fprintf(stderr, "unhandled setting F: %s\n", name);
    return 0;
 }


### PR DESCRIPTION
Commit Summary:
* Combines mixvpc_enabled and non-mixvpc_enabled draw routines.
* Move MAKECOLOR_PCE to FixPCache() and apply correct colors depending if we are running in supergrafx or non-supergrafx modes. Non-sgx mode will apply MAKECOLOR_PCE while in sgx modes will apply only in MixVPC();
* Apply MAKECOLOR_PCE to DrawOverscan when running in SuperGrafx to minimize wierd overscan colors when running non-sgx roms(need to confirm on real hardware the correct overscan colors).
* re-apply FixPCache() after setting VDC_TotalChips.
* Apply DrawOverscan optimization based from pce_fast core.
* Silence mouse_sensitivity error due to missing entry(placeholder till mouse implementation)