### PR TITLE
Cleanup

### DIFF
--- a/mednafen/pce_fast/vdc.cpp
+++ b/mednafen/pce_fast/vdc.cpp
@@ -1200,9 +1200,6 @@ void VDC_Init(int sgx)
  userle = ~0;
 
  VDC_TotalChips = sgx ? 2 : 1;
-
- for(int x = 0; x < 512; x++)
-  FixPCache(x);
 }
 
 void VDC_Close(void)


### PR DESCRIPTION
This is not needed here since a later initialization is always done on the 1st loop of Emulate()