### PR TITLE
Update mouse emulation with latest release

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1299,7 +1299,7 @@ static void set_volume (uint32_t *ptr, unsigned number)
 #define        MAX_PLAYERS 5
 #define        MAX_BUTTONS 15
 static uint8_t input_buf[MAX_PLAYERS][2]    = {{0}};
-static int32_t mousedata[MAX_PLAYERS][2]    = {{0}};
+static int16_t mousedata[MAX_PLAYERS][3]    = {{0}};
 static unsigned int input_type[MAX_PLAYERS] = {0};
 static float mouse_sensitivity              = 1.0f;
 static bool disable_softreset               = false;
@@ -1706,7 +1706,7 @@ static void update_input(void)
 
       else if (input_type[j] == RETRO_DEVICE_MOUSE)
       {
-         mousedata[j][2] = 0;
+         int16_t mouse_buttons = 0;
 
          float _x = input_state_cb(j, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
          float _y = input_state_cb(j, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
@@ -1715,9 +1715,16 @@ static void update_input(void)
          mousedata[j][1] = (int)roundf(_y * mouse_sensitivity);
 
          if (input_state_cb(j, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT))
-            mousedata[j][2] |= (1 << 0);
+            mouse_buttons |= (1 << 0); // left mouse button
          if (input_state_cb(j, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT))
-            mousedata[j][2] |= (1 << 1);
+            mouse_buttons |= (1 << 1); // right mouse button
+         if (input_state_cb(j, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))
+            mouse_buttons |= (1 << 2); // select
+         if (input_state_cb(j, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) ||
+             input_state_cb(j, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_MIDDLE))
+            mouse_buttons |= (1 << 3); // start
+
+         mousedata[j][2] = mouse_buttons;
       }
    }
 }

--- a/mednafen/pce_fast/input.cpp
+++ b/mednafen/pce_fast/input.cpp
@@ -82,9 +82,9 @@ void INPUT_Frame(void)
   }
   else if(InputTypes[x] == 2)
   {
-   mouse_x[x] += (int32)MDFN_de32lsb(data_ptr[x] + 0);
-   mouse_y[x] += (int32)MDFN_de32lsb(data_ptr[x] + 4);
-   pce_mouse_button[x] = *(uint8 *)(data_ptr[x] + 8);
+   mouse_x[x] += (int16)MDFN_de16lsb(data_ptr[x] + 0);
+   mouse_y[x] += (int16)MDFN_de16lsb(data_ptr[x] + 2);
+   pce_mouse_button[x] = *(uint8 *)(data_ptr[x] + 4);
   }
  }
 }
@@ -145,13 +145,7 @@ uint8 INPUT_Read(unsigned int A)
     mouse_rel[tmp_ri] >>= 4;
    }
    else
-   {
-    if(pce_mouse_button[tmp_ri] & 1)
-     ret ^= 0x3; //pce_mouse_button[tmp_ri];
-
-    if(pce_mouse_button[tmp_ri] & 0x2)
-     ret ^= 0x8;
-   }
+    ret ^= pce_mouse_button[tmp_ri] & 0xF;
   }
   else
   {


### PR DESCRIPTION
-(Core)Sync mouse emulation code base on latest mednafen release 1.21.3...
-(Libretro)Update mouse handling based on changes
-(Libretro)Hook up gamepad's START and SELECT when using mouse mode.
-(Libretro)Hook up middle-mouse as alternate START button.
