### PR TITLE
Update to 1.21.3

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1951,7 +1951,7 @@ void retro_set_environment(retro_environment_t cb)
       { "sgx_cdimagecache", "CD Image Cache (Restart); disabled|enabled" },
       { "sgx_cdbios", "CD Bios (Restart); System Card 3|Games Express|System Card 1|System Card 2" },
       { "sgx_forcesgx", "Force SuperGrafx Emulation (Restart); disabled|enabled" },
-      { "sgx_nospritelimit", "No Sprite Limit (Restart); disabled|enabled" },
+      { "sgx_nospritelimit", "No Sprite Limit; disabled|enabled" },
       { "sgx_ocmultiplier", "CPU Overclock Multiplier (Restart); 1|2|3|4|5|6|7|8|9|10|20|30|40|50" },
       { "sgx_hoverscan", "Horizontal Overscan (352 Width Mode Only); 352|300|302|304|306|308|310|312|314|316|318|320|322|324|326|328|330|332|334|336|338|340|342|344|346|348|350" },
       { "sgx_initial_scanline", "Initial scanline; 3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|0|1|2" },

--- a/mednafen/hw_misc/arcade_card/arcade_card.cpp
+++ b/mednafen/hw_misc/arcade_card/arcade_card.cpp
@@ -19,13 +19,7 @@
 */
 
 #include "mednafen/mednafen.h"
-
-//#include "pce.h"
-//#include "huc.h"
 #include "arcade_card.h"
-
-#include <errno.h>
-#include <string.h>
 
 static INLINE void ACAutoIncrement(ACPort_t *port)
 {

--- a/mednafen/pce_fast/huc6280.cpp
+++ b/mednafen/pce_fast/huc6280.cpp
@@ -147,7 +147,12 @@ static INLINE uint8 RdMem(unsigned int A)
 
 static INLINE uint16 RdMem16(unsigned int A)
 {
- return(RdMem(A) | (RdMem(A + 1) << 8));
+ uint16 ret;
+
+ ret = RdMem(A);
+ ret |= RdMem(A + 1) << 8;
+
+ return(ret);
 }
 
 static INLINE void WrMem(unsigned int A, uint8 V)
@@ -560,10 +565,9 @@ void HuC6280_Reset(void)
   
 void HuC6280_Init(void)
 {
-	memset((void *)&HuCPU,0,sizeof(HuCPU));
+	memset(&HuCPU,0,sizeof(HuCPU));
 
  #ifdef HUC6280_LAZY_FLAGS
-
  #else
  for(int x=0; x < 256; x++)
  {

--- a/mednafen/pce_fast/pcecd.cpp
+++ b/mednafen/pce_fast/pcecd.cpp
@@ -153,10 +153,10 @@ static INLINE int32 ADPCM_ClocksToNextEvent(void)
 {
  int32 ret = (ADPCM.bigdiv + 65535) >> 16;
 
- if(ADPCM.WritePending && ret > ADPCM.WritePending)
+ if((ADPCM.WritePending > 0) && ret > ADPCM.WritePending)
   ret = ADPCM.WritePending;
 
- if(ADPCM.ReadPending && ret > ADPCM.ReadPending)
+ if((ADPCM.ReadPending > 0) && ret > ADPCM.ReadPending)
   ret = ADPCM.ReadPending;
 
  return(ret);
@@ -781,7 +781,7 @@ static INLINE void ADPCM_Run(const int32 clocks, const int32 timestamp)
  //printf("ADPCM Run: %d\n", clocks);
  ADPCM_PB_Run(timestamp, clocks);
 
- if(ADPCM.WritePending)
+ if(ADPCM.WritePending > 0)
  {
   ADPCM.WritePending -= clocks;
   if(ADPCM.WritePending <= 0)
@@ -795,7 +795,7 @@ static INLINE void ADPCM_Run(const int32 clocks, const int32 timestamp)
   }
  }
 
- if(!ADPCM.WritePending)
+ if(ADPCM.WritePending <= 0)
  {
   if(_Port[0xb] & 0x3)
   {
@@ -810,7 +810,7 @@ static INLINE void ADPCM_Run(const int32 clocks, const int32 timestamp)
   }
  }
 
- if(ADPCM.ReadPending)
+ if(ADPCM.ReadPending > 0)
  {
   ADPCM.ReadPending -= clocks;
   if(ADPCM.ReadPending <= 0)

--- a/mednafen/pce_fast/pcecd_drive.cpp
+++ b/mednafen/pce_fast/pcecd_drive.cpp
@@ -425,7 +425,7 @@ void PCECD_Drive_SetDisc(bool tray_open, CDIF *cdif, bool no_emu_side_effects)
 
 static void CommandCCError(int key, int asc = 0, int ascq = 0)
 {
- printf("CC Error: %02x %02x %02x\n", key, asc, ascq);
+ //printf("CC Error: %02x %02x %02x\n", key, asc, ascq);
 
  cd.key_pending = key;
  cd.asc_pending = asc;
@@ -525,7 +525,7 @@ static void DoREAD6(const uint8 *cdb)
  // TODO: confirm real PCE does this(PC-FX does at least).
  if(!sc)
  {
-  SCSIDBG("READ(6) with count == 0.\n");
+  //SCSIDBG("READ(6) with count == 0.\n");
   sc = 256;
  }
 
@@ -544,7 +544,7 @@ static void DoNEC_PCE_SAPSP(const uint8 *cdb)
  //printf("Set audio start: %02x %02x %02x %02x %02x %02x %02x\n", cdb[9], cdb[1], cdb[2], cdb[3], cdb[4], cdb[5], cdb[6]);
  switch (cdb[9] & 0xc0)
  {
-  default:  SCSIDBG("Unknown SAPSP 9: %02x\n", cdb[9]);
+  default:  //SCSIDBG("Unknown SAPSP 9: %02x\n", cdb[9]);
   case 0x00:
    new_read_sec_start = (cdb[3] << 16) | (cdb[4] << 8) | cdb[5];
    break;
@@ -615,7 +615,7 @@ static void DoNEC_PCE_SAPEP(const uint8 *cdb)
 
  switch (cdb[9] & 0xc0)
  {
-  default: SCSIDBG("Unknown SAPEP 9: %02x\n", cdb[9]);
+  //default: SCSIDBG("Unknown SAPEP 9: %02x\n", cdb[9]);
 
   case 0x00:
    new_read_sec_end = (cdb[3] << 16) | (cdb[4] << 8) | cdb[5];
@@ -737,8 +737,8 @@ static void DoNEC_PCE_GETDIRINFO(const uint8 *cdb)
 
  switch(cdb[1])
  {
-  default: MDFN_DispMessage("Unknown GETDIRINFO Mode: %02x", cdb[1]);
-	   printf("Unknown GETDIRINFO Mode: %02x", cdb[1]);
+  default: //MDFN_DispMessage("Unknown GETDIRINFO Mode: %02x", cdb[1]);
+	   //printf("Unknown GETDIRINFO Mode: %02x", cdb[1]);
   case 0x0:
    data_in[0] = U8_to_BCD(toc.first_track);
    data_in[1] = U8_to_BCD(toc.last_track);
@@ -902,7 +902,7 @@ static INLINE void RunCDDA(uint32 system_timestamp, int32 run_time)
      break;
     }
 
-    if(cd.TrayOpen)
+    if(cd.TrayOpen || !Cur_CDIF)
     {
      cdda.CDDAStatus = CDDASTATUS_STOPPED;
 
@@ -996,6 +996,10 @@ static INLINE void RunCDRead(uint32 system_timestamp, int32 run_time)
      cd.data_transfer_done = FALSE;
 
      CommandCCError(SENSEKEY_NOT_READY, NSE_TRAY_OPEN);
+    }
+    else if(!Cur_CDIF)
+    {
+     CommandCCError(SENSEKEY_NOT_READY, NSE_NO_DISC);
     }
     else if(SectorAddr >= toc.tracks[100].lba)
     {
@@ -1119,7 +1123,7 @@ uint32 PCECD_Drive_Run(pcecd_drive_timestamp_t system_timestamp)
       {
        CommandCCError(SENSEKEY_ILLEGAL_REQUEST, NSE_INVALID_COMMAND);
 
-       SCSIDBG("Bad Command: %02x\n", cd.command_buffer[0]);
+       //SCSIDBG("Bad Command: %02x\n", cd.command_buffer[0]);
 
        if(SCSILog)
         SCSILog("SCSI", "Bad Command: %02x", cd.command_buffer[0]);

--- a/mednafen/pce_fast/psg.cpp
+++ b/mednafen/pce_fast/psg.cpp
@@ -653,9 +653,9 @@ int PCEFast_PSG::StateAction(StateMem *sm, int load, int data_only)
    for(int lr = 0; lr < 2; lr++)
     channel[ch].vl[lr] &= 0x1F;
 
-   if(!channel[ch].noisecount && ch >= 4)
+   if((channel[ch].noisecount <= 0) && ch >= 4)
    {
-    printf("ch=%d, noisecount == 0\n", ch);
+    printf("ch=%d, noisecount <= 0\n", ch);
     channel[ch].noisecount = 1;
    }
 

--- a/mednafen/pce_fast/vdc.cpp
+++ b/mednafen/pce_fast/vdc.cpp
@@ -599,6 +599,7 @@ static void DrawSprites(vdc_t *vdc, const int32 end, uint16 *spr_linebuf)
   const uint32 palette_index = (flags & 0xF) << 4;
 
   uint32 y_offset = vdc->RCRCount - y;
+
   if(y_offset < height)
   {
    if(active_sprites == 16)
@@ -1200,10 +1201,9 @@ void VDC_Init(int sgx)
  VDC_TotalChips = sgx ? 2 : 1;
 }
 
-void VDC_SetSettings(const bool nospritelimit, const unsigned mode1_width)
+void VDC_SetSettings(const bool nospritelimit)
 {
  unlimited_sprites = nospritelimit;
- defined_width[1] = mode1_width;
 }
 
 void VDC_Close(void)

--- a/mednafen/pce_fast/vdc.h
+++ b/mednafen/pce_fast/vdc.h
@@ -102,7 +102,6 @@ typedef struct
 } vdc_t;
 
 extern vdc_t vdc_chips[2];
-extern int VDC_TotalChips;
 
 void VDC_SetPixelFormat(const MDFN_PixelFormat &format) MDFN_COLD;
 void VDC_RunFrame(EmulateSpecStruct *espec, bool IsHES);
@@ -193,6 +192,7 @@ static INLINE uint8 VDC_Read(unsigned int A, bool SGX)
 DECLFW(VCE_Write);
 
 void VDC_Init(int sgx) MDFN_COLD;
+void VDC_SetSettings(const bool nospritelimit, const unsigned mode1_width);
 void VDC_Close(void) MDFN_COLD;
 void VDC_Reset(void) MDFN_COLD;
 void VDC_Power(void) MDFN_COLD;

--- a/mednafen/pce_fast/vdc.h
+++ b/mednafen/pce_fast/vdc.h
@@ -192,7 +192,7 @@ static INLINE uint8 VDC_Read(unsigned int A, bool SGX)
 DECLFW(VCE_Write);
 
 void VDC_Init(int sgx) MDFN_COLD;
-void VDC_SetSettings(const bool nospritelimit, const unsigned mode1_width);
+void VDC_SetSettings(const bool nospritelimit);
 void VDC_Close(void) MDFN_COLD;
 void VDC_Reset(void) MDFN_COLD;
 void VDC_Power(void) MDFN_COLD;

--- a/mednafen/pce_fast/vpc_mix_inner.inc
+++ b/mednafen/pce_fast/vpc_mix_inner.inc
@@ -23,7 +23,6 @@
 	  case 2:
                 //if((vdc1_pixel & (ALPHA_MASK << 2)) && !(vdc2_pixel & (ALPHA_MASK << 2)) && !(vdc2_pixel & ALPHA_MASK))
                 //        vdc1_pixel |= ALPHA_MASK;
-		puts("MOO");
 		// TODO: Verify that this is correct logic.
 		{
 		 const uint16 intermediate = ((vdc1_pixel ^ vdc2_pixel) & vdc1_pixel) >> 2;

--- a/mednafen/settings.cpp
+++ b/mednafen/settings.cpp
@@ -22,10 +22,10 @@
 #include "settings.h"
 
 bool setting_pce_fast_forcesgx = true;
+bool setting_pce_fast_nospritelimit = false;
 int setting_initial_scanline = 0;
 int setting_last_scanline = 242;
 int setting_pce_hoverscan = 352;
-int setting_pce_fast_nospritelimit = 0;
 int setting_pce_overclocked = 1;
 int setting_pce_fast_cddavolume = 100;
 int setting_pce_fast_adpcmvolume = 100;

--- a/mednafen/settings.h
+++ b/mednafen/settings.h
@@ -1,13 +1,11 @@
 #ifndef MDFN_SETTINGS_H
 #define MDFN_SETTINGS_H
 
-#include <string>
-
 #if defined(WANT_PCE_FAST_EMU)
 extern bool setting_pce_fast_forcesgx;
+extern bool setting_pce_fast_nospritelimit;
 extern int setting_initial_scanline;
 extern int setting_last_scanline;
-extern int setting_pce_fast_nospritelimit;
 extern int setting_pce_overclocked;
 extern int setting_pce_hoverscan;
 extern int setting_pce_fast_cddavolume;


### PR DESCRIPTION
- (core)updated pce_fast to latest mednafen 1.21.3
- (libretro) update core related to latest as well where necessary.
- Core option No Sprite Limit should not need restarting the core now...
- Set correct type to some variables...