### PR TITLE
Backport update from 1.27.0-UNSTABLE

### DIFF
--- a/mednafen/pce_fast/vdc.cpp
+++ b/mednafen/pce_fast/vdc.cpp
@@ -103,7 +103,7 @@ static INLINE void FixTileCache(vdc_t *which_vdc, uint16 A)
 {
    uint32 charname = (A >> 4);
    uint32 y = (A & 0x7);
-   uint64 *tc = &which_vdc->bg_tile_cache[charname][y];
+   uint64 *tc = which_vdc->bg_tile_cache + (charname * 8) + y;
 
    uint32 bitplane01 = which_vdc->VRAM[y + charname * 16];
    uint32 bitplane23 = which_vdc->VRAM[y + 8 + charname * 16];
@@ -573,7 +573,7 @@ static void DrawBG(const vdc_t *vdc, const uint32 count, uint8 *target)
       int line_sub = vdc->BG_YOffset & 7;
 
       const uint16 *BAT_Base = &vdc->VRAM[bat_y];
-      const uint64 *CG_Base = &vdc->bg_tile_cache[0][line_sub];
+      const uint64 *CG_Base = vdc->bg_tile_cache + (0 * 8) + line_sub;
 
       uint64 cg_mask = 0xFFFFFFFFFFFFFFFFULL;
 

--- a/mednafen/pce_fast/vdc.h
+++ b/mednafen/pce_fast/vdc.h
@@ -96,7 +96,7 @@ typedef struct
 	uint16 SAT[0x100];
 
         uint16 VRAM[65536];	//VRAM_Size];
-        uint64 bg_tile_cache[65536][8]; 	// Tile, y, x
+        uint64 bg_tile_cache[4096 * 8]; 	// Tile, y, x
         uint8 spr_tile_cache[1024][16][16];	// Tile, y, x
         uint8 spr_tile_clean[1024];     //VRAM_Size / 64];
 } vdc_t;


### PR DESCRIPTION
PCE-Fast: Fixed massive overallocation of memory for the VDC background tile cache.