### PR TITLE
PS3/PSL1GHT build fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,37 +224,18 @@ else ifeq ($(platform), qnx)
    AR = QCC -Vgcc_ntoarmv7le
    FLAGS += -D__BLACKBERRY_QNX__ -marm -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=softfp
 
-# PS3
-else ifneq (,$(filter $(platform), ps3 sncps3 psl1ght))
-   TARGET := $(TARGET_NAME)_libretro_ps3.a
-   STATIC_LINKING = 1
-   ENDIANNESS_DEFINES := -DMSB_FIRST -DBYTE_ORDER=BIG_ENDIAN
-
-   # sncps3
-   ifneq (,$(findstring sncps3,$(platform)))
-      CC = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
-      CXX = $(CC)
-      AR = $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
-      FLAGS += -DARCH_POWERPC_ALTIVEC
-      CXXFLAGS += -Xc+=exceptions
-      OLD_GCC := 1
-      NO_GCC := 1
-
-   # PS3
-   else ifneq (,$(findstring ps3,$(platform)))
-      CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
-      CXX = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-g++.exe
-      AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
-      FLAGS += -DARCH_POWERPC_ALTIVEC
-      OLD_GCC := 1
-
-   # Lightweight PS3 Homebrew SDK
-   else ifneq (,$(findstring psl1ght,$(platform)))
-      TARGET := $(TARGET_NAME)_libretro_$(platform).a
-      CC = $(PS3DEV)/ppu/bin/ppu-gcc$(EXE_EXT)
-      CXX = $(PS3DEV)/ppu/bin/ppu-g++$(EXE_EXT)
-      AR = $(PS3DEV)/ppu/bin/ppu-ar$(EXE_EXT)
-   endif
+# Lightweight PS3 Homebrew SDK
+else ifneq (,$(filter $(platform), ps3 psl1ght))
+    TARGET := $(TARGET_NAME)_libretro_$(platform).a
+    STATIC_LINKING = 1
+    CC = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)gcc$(EXE_EXT)
+    CXX = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)g++$(EXE_EXT)
+    AR = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)ar$(EXE_EXT)
+    FLAGS += -DARCH_POWERPC_ALTIVEC -D__PS3__ -DMSB_FIRST -DBYTE_ORDER=BIG_ENDIAN -DUSE_LIBRETRO_VFS
+    OLD_GCC := 1
+    ifeq ($(platform), psl1ght)
+        FLAGS += -D__PSL1GHT__
+    endif
 
 # PSP
 else ifeq ($(platform), psp1)

--- a/deps/libchdr/include/libchdr/coretypes.h
+++ b/deps/libchdr/include/libchdr/coretypes.h
@@ -20,6 +20,14 @@ typedef int32_t INT32;
 typedef int16_t INT16;
 typedef int8_t INT8;
 
+#ifdef USE_LIBRETRO_VFS
+#define core_file RFILE
+#define core_fopen(file) rfopen(file, "rb")
+#define core_fseek rfseek
+#define core_ftell rftell
+#define core_fread(fc, buff, len) fread(buff, 1, len, fc)
+#define core_fclose rfclose
+#else
 #define core_file FILE
 #define core_fopen(file) fopen(file, "rb")
 #if defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(__WIN64__)
@@ -34,6 +42,7 @@ typedef int8_t INT8;
 #endif
 #define core_fread(fc, buff, len) fread(buff, 1, len, fc)
 #define core_fclose fclose
+#endif /* USE_LIBRETRO_VFS */
 
 static UINT64 core_fsize(core_file *f)
 {

--- a/deps/lzma-19.00/include/7zTypes.h
+++ b/deps/lzma-19.00/include/7zTypes.h
@@ -63,7 +63,10 @@ typedef int WRes;
 #define RINOK(x) { int __result__ = (x); if (__result__ != 0) return __result__; }
 #endif
 
+#if !defined(__BYTE_DEFINED__)
 typedef unsigned char Byte;
+#define __BYTE_DEFINED__
+#endif
 typedef short Int16;
 typedef unsigned short UInt16;
 

--- a/deps/zlib-1.2.11/zconf.h
+++ b/deps/zlib-1.2.11/zconf.h
@@ -387,8 +387,9 @@
 #  define FAR
 #endif
 
-#if !defined(__MACTYPES__)
+#if !defined(__MACTYPES__) && !defined(__BYTE_DEFINED__)
 typedef unsigned char  Byte;  /* 8 bits */
+#define __BYTE_DEFINED__
 #endif
 typedef unsigned int   uInt;  /* 16 bits or more */
 typedef unsigned long  uLong; /* 32 bits or more */

--- a/mednafen/mednafen-endian.h
+++ b/mednafen/mednafen-endian.h
@@ -2,6 +2,7 @@
 #define __MDFN_ENDIAN_H
 
 #include <stdint.h>
+#include <stdio.h>
 
 #include <retro_inline.h>
 


### PR DESCRIPTION
Added retro compatibility to old gcc 4.x where redefinition of a typedef cause an error and not a warning (`typedef unsigned char Byte;` inside 7zTypes.h and zconf.h)